### PR TITLE
feat(util): Allow passing a torch.device instance

### DIFF
--- a/ckip_transformers/nlp/util.py
+++ b/ckip_transformers/nlp/util.py
@@ -61,12 +61,17 @@ class CkipTokenClassification(metaclass=ABCMeta):
         model_name: str,
         tokenizer_name: Optional[str] = None,
         *,
-        device: int = -1,
+        device: int | torch.device = -1,
     ):
         self.model = AutoModelForTokenClassification.from_pretrained(model_name)
         self.tokenizer = BertTokenizerFast.from_pretrained(tokenizer_name or model_name)
 
-        self.device = torch.device("cpu" if device < 0 else f"cuda:{device}")  # pylint: disable=no-member
+        # Allow passing a customized torch.device.
+        if isinstance(device, torch.device):
+            self.device = device
+        else:
+            self.device = torch.device("cpu" if device < 0 else f"cuda:{device}")  # pylint: disable=no-member
+
         self.model.to(self.device)
 
     ########################################################################################################################


### PR DESCRIPTION
Abstract
======

This PR allows us passing the `torch.device` constructed by ourselves, which is useful in using `mps` [^1] as the backend instead of CUDA's.

Usage
=====

```py
device = torch.device("mps")
ws_driver = CkipWordSegmenter(model="bert-base", device=device)
```

Tests
====

I have tested in my Apple Silicon device, with the nightly version of PyTorch.
It works as intended without any observable bugs.

[^1]: https://pytorch.org/docs/stable/notes/mps.html